### PR TITLE
File structure reorg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,3 @@
 module.exports = {
-  extends: ['airbnb', 'prettier', 'prettier/react'],
-  parser: 'babel-eslint',
-  parserOptions: {
-    ecmaVersion: 2020,
-    ecmaFeatures: {
-      impliedStrict: true,
-      classes: true,
-    },
-  },
-  env: {
-    browser: true,
-    node: true,
-    jquery: true,
-    jest: true,
-  },
-  rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        arrowParens: 'avoid',
-        printWidth: 85,
-        trailingComma: 'all',
-        useTabs: false,
-        tabWidth: 2,
-        semi: true,
-        singleQuote: true,
-      },
-    ],
-  },
-  plugins: ['prettier', 'react-hooks'],
+  extends: ['./packages/base'],
 };

--- a/README.md
+++ b/README.md
@@ -4,28 +4,36 @@ NPM package for shared ESLint config used at JuniLearning.
 
 ## Usage
 
+### For all projects:
+
 1. `npm i --save-dev eslint-config-juni`
 2. Install peer dependencies: `npx install-peerdeps --dev eslint-config-juni`
-3. Available config options at the moment are 'base' and 'react'. If you include 'react' in your project, it will also include 'base,' but not vice-versa. Include them accordingly based on the environment of your project.
-4. Create a file called `.eslintrc.js` in the project root, next to `package.json`:
-   For non-React projects:
+3. Create a file called `.eslintrc.js` in the project root, next to `package.json`. Leave it empty for now. The contents will vary depending on the repo's environment type.
+
+### `.eslintrc.js` contents:
+
+_React projects:_
 
 ```js
 module.exports = {
-  extends: ["juni/base"],
+  extends: ["juni/packages/base", "juni/packages/react"],
 };
 ```
 
-For React projects:
+_Non-React projects_
 
 ```js
 module.exports = {
-  extends: ["juni/react"],
+  extends: ["juni/packages/base"],
 };
 ```
 
-5. (optional) Enable format on save capabilities in VSCode using the Juni linting config.
-   Add the following to `./.vscode/settings.json`:
+(more configs coming soon)
+
+## VSCode setup
+
+Enable format on save capabilities in VSCode using the Juni linting config.
+Add the following to `./.vscode/settings.json`:
 
 ```json
   // enables VSCode's default formatter

--- a/README.md
+++ b/README.md
@@ -1,29 +1,32 @@
 # eslint-config-juni
+
 NPM package for shared ESLint config used at JuniLearning.
 
-
-# How to publish
-```bash
-# run only once to install publishing tool
-npm i np -g 
-```
-
-```bash
-np --no-tests
-```
-
 ## Usage
+
 1. `npm i --save-dev eslint-config-juni`
 2. Install peer dependencies: `npx install-peerdeps --dev eslint-config-juni`
-3. Create a file called `.eslintrc.js` in the project root, next to `package.json`:
+3. Available config options at the moment are 'base' and 'react'. If you include 'react' in your project, it will also include 'base,' but not vice-versa. Include them accordingly based on the environment of your project.
+4. Create a file called `.eslintrc.js` in the project root, next to `package.json`:
+   For non-React projects:
+
 ```js
 module.exports = {
-  extends: ['juni'],
+  extends: ["juni/base"],
 };
 ```
 
-4. (optional) Enable format on save capabilities in VSCode using the Juni linting config. 
-Add the following to `./.vscode/settings.json`:
+For React projects:
+
+```js
+module.exports = {
+  extends: ["juni/react"],
+};
+```
+
+5. (optional) Enable format on save capabilities in VSCode using the Juni linting config.
+   Add the following to `./.vscode/settings.json`:
+
 ```json
   // enables VSCode's default formatter
   "editor.formatOnSave": true,
@@ -43,4 +46,15 @@ Add the following to `./.vscode/settings.json`:
     "javascriptreact"
   ],
   "eslint.alwaysShowStatus": true
+```
+
+# How to publish
+
+```bash
+# run only once to install publishing tool
+npm i np -g
+```
+
+```bash
+np --no-tests
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "juni-linting-config",
+  "name": "eslint-config-juni",
   "version": "0.0.9",
   "lockfileVersion": 1,
   "requires": true,
@@ -8,6 +8,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
       "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.10.4"
       }
@@ -16,6 +17,7 @@
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
       "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.5",
         "jsesc": "^2.5.1",
@@ -26,6 +28,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
       "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.10.4",
         "@babel/template": "^7.10.4",
@@ -36,6 +39,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
       "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.4"
       }
@@ -44,6 +48,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
       "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.4"
       }
@@ -51,12 +56,14 @@
     "@babel/helper-validator-identifier": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
     },
     "@babel/highlight": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
       "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
@@ -66,7 +73,8 @@
     "@babel/parser": {
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ=="
+      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
+      "dev": true
     },
     "@babel/runtime": {
       "version": "7.10.5",
@@ -91,6 +99,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
       "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/parser": "^7.10.4",
@@ -101,6 +110,7 @@
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
       "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/generator": "^7.10.5",
@@ -117,6 +127,7 @@
       "version": "7.10.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
       "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
+      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.19",
@@ -186,6 +197,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -269,6 +281,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",
@@ -304,6 +317,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -335,6 +349,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -342,7 +357,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -389,6 +405,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -465,7 +482,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "7.2.0",
@@ -598,6 +616,7 @@
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
       "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
       }
@@ -735,6 +754,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
       "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
@@ -797,7 +817,8 @@
     "eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
     },
     "espree": {
       "version": "7.1.0",
@@ -874,7 +895,8 @@
     "fast-diff": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -953,7 +975,8 @@
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -981,7 +1004,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -1001,7 +1025,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -1224,7 +1249,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
@@ -1239,7 +1265,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -1322,7 +1349,8 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1366,7 +1394,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -1566,7 +1595,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-type": {
       "version": "2.0.0",
@@ -1601,12 +1631,14 @@
     "prettier": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg=="
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
       "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
       "requires": {
         "fast-diff": "^1.1.2"
       }
@@ -1687,6 +1719,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -1796,7 +1829,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -1906,6 +1940,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -1986,7 +2021,8 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "test": "./test.sh",
     "publish": "npx np --no-tests",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix"
+    "lint:fix": "eslint --fix",
+    "preinstall": "npm run install:base && npm run install:react",
+    "install:base": "cd packages/base && npm install --dev",
+    "install:react": "cd packages/react && npm install --dev"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {
     "test": "./test.sh",
     "publish": "npx np --no-tests",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix"
+    "lint:fix": "eslint . --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "test": "./test.sh",
     "publish": "npx np --no-tests",
     "lint": "eslint .",
-    "lint:fix": "eslint --fix",
-    "preinstall": "npm run install:base && npm run install:react",
-    "install:base": "cd packages/base && npm install --dev",
-    "install:react": "cd packages/react && npm install --dev"
+    "lint:fix": "eslint --fix"
   },
   "repository": {
     "type": "git",

--- a/packages/base/.eslintrc.js
+++ b/packages/base/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-  extends: "./index.js",
+  extends: './index.js',
   rules: {},
 };

--- a/packages/base/.eslintrc.js
+++ b/packages/base/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: "./index.js",
+  rules: {},
+};

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,0 +1,25 @@
+module.exports = {
+  extends: [
+    'airbnb',
+    'prettier',
+    './rules/best-practices',
+    './rules/styles',
+    './rules/prettier.js'
+  ].map(require.resolve),
+  env: {
+    browser: true,
+    node: true,
+    jquery: true,
+    jest: true,
+  },
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2020,
+    ecmaFeatures: {
+      impliedStrict: true,
+      classes: true,
+    },
+  },
+  rules: {},
+  plugins: ['prettier', 'react-hooks'],
+}

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -21,5 +21,4 @@ module.exports = {
     },
   },
   rules: {},
-  plugins: ['prettier'],
 };

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
-    '../../node_modules/eslint-config-airbnb-base',
-    '../../node_modules/eslint-config-prettier',
+    'eslint-config-airbnb-base',
+    'eslint-config-prettier',
     './rules/best-practices',
     './rules/styles',
     './rules/prettier.js',

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -1,10 +1,10 @@
 module.exports = {
   extends: [
-    'airbnb',
-    'prettier',
+    '../../node_modules/eslint-config-airbnb-base',
+    '../../node_modules/eslint-config-prettier',
     './rules/best-practices',
     './rules/styles',
-    './rules/prettier.js'
+    './rules/prettier.js',
   ].map(require.resolve),
   env: {
     browser: true,
@@ -21,5 +21,5 @@ module.exports = {
     },
   },
   rules: {},
-  plugins: ['prettier', 'react-hooks'],
-}
+  plugins: ['prettier'],
+};

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -31,7 +31,7 @@ module.exports = {
         allowTaggedTemplates: true,
       },
     ],
-    'no-param-reassign': [ 2, { props: false } ],
+    'no-param-reassign': [2, { props: false }],
     'no-console': 0,
-  }
-}
+  },
+};

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -1,37 +1,36 @@
 module.exports = {
   rules: {
+    // disallows debugger statements
     'no-debugger': 0,
+    // disallow use of window.alert()
     'no-alert': 0,
+    // disallows use of await in loops
     'no-await-in-loop': 0,
-    'no-return-assign': ['error', 'except-parens'],
+    // disallows assignment in a return statement, e.g. return foo = bar + 2;
+    'no-return-assign': ['error'],
+    // restricts the use of various...unsavory... JavaScript features. Takes an array of ESTree node types.
     'no-restricted-syntax': [
       2,
       'ForInStatement',
       'LabeledStatement',
       'WithStatement',
     ],
+    // every variable should be used, exported, or returned
     'no-unused-vars': [
       'error',
-      {
-        vars: 'all',
-        args: 'after-used',
-        ignoreRestSiblings: false,
-      },
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
     ],
-    'prefer-const': [
-      'error',
-      {
-        destructuring: 'all',
-      },
-    ],
+    // use const where possible, rather than let or var
+    // prettier-ignore
+    'prefer-const': [ 'error', { destructuring: 'all' } ],
+    // enforces braces in an arrow function body where possible, but able to omit if not needed
     'arrow-body-style': [2, 'as-needed'],
-    'no-unused-expressions': [
-      2,
-      {
-        allowTaggedTemplates: true,
-      },
-    ],
+    // every expression should be used or returned within the scope
+    // prettier-ignore
+    'no-unused-expressions': [ 2, { allowTaggedTemplates: true } ],
+    // disallows changing the value of a parameter.
     'no-param-reassign': [2, { props: false }],
+    // disables console. methods
     'no-console': 0,
   },
 };

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -31,12 +31,7 @@ module.exports = {
         allowTaggedTemplates: true,
       },
     ],
-    'no-param-reassign': [
-      2,
-      {
-        props: false,
-      },
-    ],
+    'no-param-reassign': [ 2, { props: false } ],
     'no-console': 0,
   }
 }

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -1,0 +1,42 @@
+module.exports = {
+  rules: {
+    'no-debugger': 0,
+    'no-alert': 0,
+    'no-await-in-loop': 0,
+    'no-return-assign': ['error', 'except-parens'],
+    'no-restricted-syntax': [
+      2,
+      'ForInStatement',
+      'LabeledStatement',
+      'WithStatement',
+    ],
+    'no-unused-vars': [
+      'error',
+      {
+        vars: 'all',
+        args: 'after-used',
+        ignoreRestSiblings: false,
+      },
+    ],
+    'prefer-const': [
+      'error',
+      {
+        destructuring: 'all',
+      },
+    ],
+    'arrow-body-style': [2, 'as-needed'],
+    'no-unused-expressions': [
+      2,
+      {
+        allowTaggedTemplates: true,
+      },
+    ],
+    'no-param-reassign': [
+      2,
+      {
+        props: false,
+      },
+    ],
+    'no-console': 0,
+  }
+}

--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ['prettier'],
   rules: {
     'prettier/prettier': [
       'error',

--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -1,0 +1,16 @@
+module.exports = {
+  rules: {
+    'prettier/prettier': [
+      'error',
+      {
+        arrowParens: 'avoid',
+        printWidth: 85,
+        trailingComma: 'all',
+        useTabs: false,
+        tabWidth: 2,
+        semi: true,
+        singleQuote: true,
+      },
+    ],
+  }
+}

--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -4,13 +4,32 @@ module.exports = {
     'prettier/prettier': [
       'error',
       {
+        // If an arrow function has one parameter, don't use parenthesis: e.g. const foo = bar => value; vs. const foo = (bar) => value;
         arrowParens: 'avoid',
+        // length of a line that Prettier will wrap on
         printWidth: 85,
+        /*
+         Trailing comma on _multi-line_ objects and arrays
+         good: [
+           'foo',
+           'bar',
+           'baz',
+         ]
+
+         bad: [
+           'foo',
+           'bar',
+           'baz'
+          ]
+        */
         trailingComma: 'all',
+        // use spaces vs. tabs
         useTabs: false,
+        // number of spaces when tab key is pressed
         tabWidth: 2,
-        semi: true,
+        // use single quotes vs. double quotes where possible
         singleQuote: true,
+        // use semicolons where possible
         semicolons: true,
       },
     ],

--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -11,6 +11,7 @@ module.exports = {
         tabWidth: 2,
         semi: true,
         singleQuote: true,
+        semicolons: true,
       },
     ],
   },

--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -12,5 +12,5 @@ module.exports = {
         singleQuote: true,
       },
     ],
-  }
-}
+  },
+};

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'import/prefer-default-export': 0,
+    'import': 0,
+    'func-names': 0,
+    'space-before-function-paren': 0,
+    'comma-dangle': 0,
+    'max-len': 0,
+    'import/extensions': 0,
+    'no-underscore-dangle': 0,
+    'consistent-return': 0
+  }
+}

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -1,13 +1,20 @@
 module.exports = {
   rules: {
+    // Enforces using a default export if you only have one export from a file
     'import/prefer-default-export': 0,
-    import: 0,
-    'func-names': 0,
-    'space-before-function-paren': 0,
-    'comma-dangle': 0,
-    'max-len': 0,
+    // provides standards around importing a file with or without a file extension
     'import/extensions': 0,
+    // Enforces naming an otherwise anonymous function: https://eslint.org/docs/rules/func-names
+    'func-names': 0,
+    // enforces a space before function parameters, e.g. function foo() {} vs. function foo ()
+    'space-before-function-paren': 0,
+    // enforces trailing comma in an object or array (enabled in Prettier trailingComma)
+    'comma-dangle': 0,
+    // enforces break on a long time (enabled in Prettier printWidth)
+    'max-len': 0,
+    // disables underscores in identifiers
     'no-underscore-dangle': 0,
+    // requires return statements to either always, or never, specify values
     'consistent-return': 0,
   },
 };

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -1,13 +1,13 @@
 module.exports = {
   rules: {
     'import/prefer-default-export': 0,
-    'import': 0,
+    import: 0,
     'func-names': 0,
     'space-before-function-paren': 0,
     'comma-dangle': 0,
     'max-len': 0,
     'import/extensions': 0,
     'no-underscore-dangle': 0,
-    'consistent-return': 0
-  }
-}
+    'consistent-return': 0,
+  },
+};

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  extends: [
+    "../base",
+    "./index.js"
+  ],
+  rules: {}
+};

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  extends: [
-    "../base",
-    "./index.js"
-  ],
-  rules: {}
+  extends: ['../base', './index.js'],
+  rules: {},
 };

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,9 +1,10 @@
 module.exports = {
   extends: [
-    'airbnb',
-    'prettier',
-    'prettier/react',
+    '../../node_modules/eslint-config-airbnb',
+    '../../node_modules/eslint-config-prettier',
+    '../../node_modules/eslint-config-prettier/react',
     './rules/react',
+    './rules/react-hooks',
     './rules/jsx-a11y.js',
   ].map(require.resolve),
   parser: 'babel-eslint',
@@ -15,4 +16,4 @@ module.exports = {
     },
   },
   rules: {},
-}
+};

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: [
+    'airbnb',
+    'prettier',
+    'prettier/react',
+    './rules/react',
+    './rules/jsx-a11y.js',
+  ].map(require.resolve),
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2020,
+    ecmaFeatures: {
+      impliedStrict: true,
+      classes: true,
+    },
+  },
+  rules: {},
+}

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -1,8 +1,8 @@
 module.exports = {
   extends: [
-    '../../node_modules/eslint-config-airbnb',
-    '../../node_modules/eslint-config-prettier',
-    '../../node_modules/eslint-config-prettier/react',
+    'eslint-config-airbnb',
+    'eslint-config-prettier',
+    'eslint-config-prettier/react',
     './rules/react',
     './rules/react-hooks',
     './rules/jsx-a11y.js',

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -7,6 +7,6 @@ module.exports = {
       {
         aspects: ['invalidHref'],
       },
-    ]
-  }
-}
+    ],
+  },
+};

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -1,12 +1,7 @@
 module.exports = {
   rules: {
-    'jsx-a11y/accessible-emoji': 0,
-    'jsx-a11y/href-no-hash': 'off',
-    'jsx-a11y/anchor-is-valid': [
-      'warn',
-      {
-        aspects: ['invalidHref'],
-      },
-    ],
+    // eslint-ignore
+    // check that anchor contains a valid href, e.g. "/link" or "#hash". Avoids using onClick handlers on <a> tags where you should use a button instead.
+    'jsx-a11y/anchor-is-valid': ['warn', { aspects: ['invalidHref'] }],
   },
 };

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -1,0 +1,12 @@
+module.exports = {
+  rules: {
+    'jsx-a11y/accessible-emoji': 0,
+    'jsx-a11y/href-no-hash': 'off',
+    'jsx-a11y/anchor-is-valid': [
+      'warn',
+      {
+        aspects: ['invalidHref'],
+      },
+    ]
+  }
+}

--- a/packages/react/rules/react-hooks.js
+++ b/packages/react/rules/react-hooks.js
@@ -1,7 +1,9 @@
 module.exports = {
   plugins: ['react-hooks'],
   rules: {
+    // shows an error when 1) A hook is called from a class-based component or non-React function, and 2) Hook is NOT called conditionally
     'react-hooks/rules-of-hooks': 'error',
+    // warns when dependency arrays don't include all of the outside functions and properties that it mentions.
     'react-hooks/exhaustive-deps': 'warn',
   },
 };

--- a/packages/react/rules/react-hooks.js
+++ b/packages/react/rules/react-hooks.js
@@ -1,4 +1,4 @@
 module.exports = {
   'react-hooks/rules-of-hooks': 'error',
-  'react-hooks/exhaustive-deps': 'warn'
-}
+  'react-hooks/exhaustive-deps': 'warn',
+};

--- a/packages/react/rules/react-hooks.js
+++ b/packages/react/rules/react-hooks.js
@@ -1,0 +1,4 @@
+module.exports = {
+  'react-hooks/rules-of-hooks': 'error',
+  'react-hooks/exhaustive-deps': 'warn'
+}

--- a/packages/react/rules/react-hooks.js
+++ b/packages/react/rules/react-hooks.js
@@ -1,4 +1,7 @@
 module.exports = {
-  'react-hooks/rules-of-hooks': 'error',
-  'react-hooks/exhaustive-deps': 'warn',
+  plugins: ['react-hooks'],
+  rules: {
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+  },
 };

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -1,17 +1,16 @@
 module.exports = {
   rules: {
-    'react/display-name': 1,
-    'react/no-array-index-key': 0,
+    // warns if an array index is used as a key
+    'react/no-array-index-key': 1,
+    // disables requiring React to be declared in scope of JSX elements (React is defined globally in every file that uses it)
     'react/react-in-jsx-scope': 0,
-    'react/prefer-stateless-function': 0,
-    'react/forbid-prop-types': 0,
+    // warns if a class-based component should be a functional component
+    'react/prefer-stateless-function': 1,
+    // prevents characters that you may have meant as JSX escape characters from being accidentally injected as a text node in JSX statements.
     'react/no-unescaped-entities': 0,
+    // ensures that any non-required prop types of a component has a corresponding defaultProps value.
     'react/require-default-props': 0,
-    'react/jsx-filename-extension': [
-      1,
-      {
-        extensions: ['.js', '.jsx'],
-      },
-    ],
+    // eslint-ignore
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
   },
 };

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -1,0 +1,17 @@
+module.exports = {
+  rules: {
+    'react/display-name': 1,
+    'react/no-array-index-key': 0,
+    'react/react-in-jsx-scope': 0,
+    'react/prefer-stateless-function': 0,
+    'react/forbid-prop-types': 0,
+    'react/no-unescaped-entities': 0,
+    'react/require-default-props': 0,
+    'react/jsx-filename-extension': [
+      1,
+      {
+        extensions: ['.js', '.jsx'],
+      },
+    ]
+  }
+}

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -12,6 +12,6 @@ module.exports = {
       {
         extensions: ['.js', '.jsx'],
       },
-    ]
-  }
-}
+    ],
+  },
+};

--- a/test.js
+++ b/test.js
@@ -1,0 +1,6 @@
+const lukeSkywalker = 'Luke Skywalker';
+
+// bad
+const obj = {
+  lukeSkywalker,
+};


### PR DESCRIPTION
Reorganized the file structure to include various configs that can be included according to the environment (in the `packages` folder). 

It's similar to Airbnb's config, but differs in that they have each folder in `packages` as its own separate npm package. I haven't tested integrating this with one of our repos yet because I don't want to publish a non-master branch to the npm repo, but we should be able to include the configs in a project by adding:
```js
extends: [
  'juni/base'
]
```

or 

```js
extends: [
  'juni/react'
]
```

I will start a stacked branch on this that includes rules for typescript and react-typescript. 

*Side question:*
Do you think we need a specific config for Node? Or should that be covered in `/base`?