### PR TITLE
Less strict rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.9",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./test.sh",
-    "publish": "npx np --no-tests",
+    "publish": "npx np --no-tests --any-branch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -7,10 +7,6 @@ module.exports = {
     './rules/prettier.js',
     './rules/imports.js',
   ].map(require.resolve),
-  env: {
-    exmaVersion: 2020,
-    sourceType: 'module',
-  },
   parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 6,

--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -5,20 +5,16 @@ module.exports = {
     './rules/best-practices',
     './rules/styles',
     './rules/prettier.js',
+    './rules/imports.js',
   ].map(require.resolve),
   env: {
-    browser: true,
-    node: true,
-    jquery: true,
-    jest: true,
+    exmaVersion: 2020,
+    sourceType: 'module',
   },
   parser: 'babel-eslint',
   parserOptions: {
-    ecmaVersion: 2020,
-    ecmaFeatures: {
-      impliedStrict: true,
-      classes: true,
-    },
+    ecmaVersion: 6,
+    sourceType: 'module',
   },
   rules: {},
 };

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -15,11 +15,6 @@ module.exports = {
       'LabeledStatement',
       'WithStatement',
     ],
-    // every variable should be used, exported, or returned
-    'no-unused-vars': [
-      'error',
-      { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
-    ],
     // use const where possible, rather than let or var
     // prettier-ignore
     'prefer-const': [ 'error', { destructuring: 'all' } ],
@@ -36,5 +31,14 @@ module.exports = {
     'max-classes-per-file': 0,
     // Throws error if you have multiple levels in a ternary.
     'no-nested-ternary': 0,
+    // Disabling the following 3 for backwards compatibility, but they will be added back in asap in favor of the comment below
+    'no-undef': 0,
+    'no-unused-vars': 0,
+    'no-shadow': 0,
+    // every variable should be used, exported, or returned
+    // 'no-unused-vars': [
+    //   'error',
+    //   { vars: 'all', args: 'after-used', ignoreRestSiblings: false },
+    // ],
   },
 };

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -1,14 +1,14 @@
 module.exports = {
   rules: {
-    // disallows debugger statements
-    'no-debugger': 0,
-    // disallow use of window.alert()
+    // disallows debugger statements. Leaving as a warning so they are not committed, but are less loud when developing.
+    'no-debugger': 1,
+    // disallow use of window.alert(). We still use this in a few cases, specifically in the admin tools.
     'no-alert': 0,
-    // disallows use of await in loops
+    // disallows use of await in loops. Disabling because this is used in a few of our scripts.
     'no-await-in-loop': 0,
     // disallows assignment in a return statement, e.g. return foo = bar + 2;
     'no-return-assign': ['error'],
-    // restricts the use of various...unsavory... JavaScript features. Takes an array of ESTree node types.
+    // restricts the use of various outdated JavaScript features. Takes an array of ESTree node types.
     'no-restricted-syntax': [
       2,
       'ForInStatement',
@@ -25,12 +25,13 @@ module.exports = {
     'no-unused-expressions': [ 2, { allowTaggedTemplates: true } ],
     // disallows changing the value of a parameter.
     'no-param-reassign': [2, { props: false }],
-    // disables console. methods
+    // disables console. methods. Disabling as we use console.error and log in a few places selectively in-app.
+    // todo in the future, we should only lint console.log statements and leave all console.warn statements.
     'no-console': 0,
     // enforces a certain number of classes per file, defaults to 1. Disabled due to several files with multiple, smaller React Class components
     'max-classes-per-file': 0,
-    // Throws error if you have multiple levels in a ternary.
-    'no-nested-ternary': 0,
+    // Throws error if you have multiple levels in a ternary. Warns as we do this in a few cases, but we will add eslint-ignore
+    'no-nested-ternary': 1,
     // Disabling the following 3 for backwards compatibility, but they will be added back in asap in favor of the comment below
     'no-undef': 0,
     'no-unused-vars': 0,

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -32,5 +32,7 @@ module.exports = {
     'no-param-reassign': [2, { props: false }],
     // disables console. methods
     'no-console': 0,
+    // enforces a certain number of classes per file, defaults to 1. Enabled due to several files with multiple, smaller React Class components
+    'max-classes-per-file': 0,
   },
 };

--- a/packages/base/rules/best-practices.js
+++ b/packages/base/rules/best-practices.js
@@ -34,5 +34,7 @@ module.exports = {
     'no-console': 0,
     // enforces a certain number of classes per file, defaults to 1. Enabled due to several files with multiple, smaller React Class components
     'max-classes-per-file': 0,
+    // Throws error if you have multiple levels in a ternary.
+    'no-nested-ternary': 0,
   },
 };

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -1,11 +1,4 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'module',
-  },
   plugins: ['import'],
   rules: {
     // Enforces using a default export if you only have one export from a file

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: ['import'],
   rules: {
-    // Enforces using a default export if you only have one export from a file.
+    // Enforces using a default export if you only have one export from a file. Disabled as there is marginal value for high cost to implement, files with multiple exports might not necessitate a default export.
     'import/prefer-default-export': 0,
     // provides standards around importing a file with or without a file extension. Disabled for backwards compatibility.
     'import/extensions': 0,

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -1,0 +1,16 @@
+module.exports = {
+  env: {
+    es6: true,
+  },
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+  plugins: ['import'],
+  rules: {
+    // Enforces using a default export if you only have one export from a file
+    'import/prefer-default-export': 0,
+    // provides standards around importing a file with or without a file extension
+    'import/extensions': 0,
+  },
+};

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -6,8 +6,8 @@ module.exports = {
     // provides standards around importing a file with or without a file extension
     'import/extensions': 0,
     // Forbids the import of external modules that are not declared in package.json
-    'import/no-extraneous/dependencies': 0,
+    'import/no-extraneous-dependencies': 0,
     // ensures an imported module can be resolve to a module on the local filesystem
-    'no-unresolved': 0,
+    'import/no-unresolved': 0,
   },
 };

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -5,5 +5,9 @@ module.exports = {
     'import/prefer-default-export': 0,
     // provides standards around importing a file with or without a file extension
     'import/extensions': 0,
+    // Forbids the import of external modules that are not declared in package.json
+    'import/no-extraneous/dependencies': 0,
+    // ensures an imported module can be resolve to a module on the local filesystem
+    'no-unresolved': 0,
   },
 };

--- a/packages/base/rules/imports.js
+++ b/packages/base/rules/imports.js
@@ -1,11 +1,12 @@
 module.exports = {
   plugins: ['import'],
   rules: {
-    // Enforces using a default export if you only have one export from a file
+    // Enforces using a default export if you only have one export from a file.
     'import/prefer-default-export': 0,
-    // provides standards around importing a file with or without a file extension
+    // provides standards around importing a file with or without a file extension. Disabled for backwards compatibility.
     'import/extensions': 0,
-    // Forbids the import of external modules that are not declared in package.json
+    // todo The following two are disabled for backwards compatibility but should be added back in at a later point.
+    // Forbids the import of external modules that are not declared in package.json.
     'import/no-extraneous-dependencies': 0,
     // ensures an imported module can be resolve to a module on the local filesystem
     'import/no-unresolved': 0,

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -1,18 +1,18 @@
 module.exports = {
   rules: {
-    // Enforces naming an otherwise anonymous function: https://eslint.org/docs/rules/func-names
+    // Enforces naming an otherwise anonymous function: https://eslint.org/docs/rules/func-names. Disabling as we use anonymous functions often.
     'func-names': 0,
     // enforces a space before function parameters, e.g. function foo() {} vs. function foo ()
-    'space-before-function-paren': 0,
+    'space-before-function-paren': 2,
     // enforces trailing comma in an object or array (enabled in Prettier trailingComma)
     'comma-dangle': 0,
     // enforces break on a long time (enabled in Prettier printWidth)
     'max-len': 0,
     // disables underscores in identifiers
     'no-underscore-dangle': 0,
-    // requires return statements to either always, or never, specify values
+    // requires return statements to either always, or never, specify values. Disabling for flexibility.
     'consistent-return': 0,
-    // enforces lines between methods in a class
+    // enforces lines between methods in a class. Disabling for backwards compability && low benefit.
     'lines-between-class-members': 0,
   },
 };

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -1,9 +1,5 @@
 module.exports = {
   rules: {
-    // Enforces using a default export if you only have one export from a file
-    'import/prefer-default-export': 0,
-    // provides standards around importing a file with or without a file extension
-    'import/extensions': 0,
     // Enforces naming an otherwise anonymous function: https://eslint.org/docs/rules/func-names
     'func-names': 0,
     // enforces a space before function parameters, e.g. function foo() {} vs. function foo ()

--- a/packages/base/rules/styles.js
+++ b/packages/base/rules/styles.js
@@ -12,5 +12,7 @@ module.exports = {
     'no-underscore-dangle': 0,
     // requires return statements to either always, or never, specify values
     'consistent-return': 0,
+    // enforces lines between methods in a class
+    'lines-between-class-members': 0,
   },
 };

--- a/packages/react/index.js
+++ b/packages/react/index.js
@@ -6,6 +6,7 @@ module.exports = {
     './rules/react',
     './rules/react-hooks',
     './rules/jsx-a11y.js',
+    '../base',
   ].map(require.resolve),
   parser: 'babel-eslint',
   parserOptions: {

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -4,5 +4,8 @@ module.exports = {
     // eslint-ignore
     // check that anchor contains a valid href, e.g. "/link" or "#hash". Avoids using onClick handlers on <a> tags where you should use a button instead.
     'jsx-a11y/anchor-is-valid': ['warn', { aspects: ['invalidHref'] }],
+    'jsx-a11y/label-has-associated-control': 0,
+    'jsx-a11y/click-events-have-key-events': 0,
+    'jsx-a11y/no-static-element-interactions': 0,
   },
 };

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -4,6 +4,7 @@ module.exports = {
     // eslint-ignore
     // check that anchor contains a valid href, e.g. "/link" or "#hash". Avoids using onClick handlers on <a> tags where you should use a button instead.
     'jsx-a11y/anchor-is-valid': ['warn', { aspects: ['invalidHref'] }],
+    // todo The following 3 are disabled for backwards compatibility, but should be added in later.
     'jsx-a11y/label-has-associated-control': 0,
     'jsx-a11y/click-events-have-key-events': 0,
     'jsx-a11y/no-static-element-interactions': 0,

--- a/packages/react/rules/jsx-a11y.js
+++ b/packages/react/rules/jsx-a11y.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ['jsx-a11y'],
   rules: {
     // eslint-ignore
     // check that anchor contains a valid href, e.g. "/link" or "#hash". Avoids using onClick handlers on <a> tags where you should use a button instead.

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -17,5 +17,9 @@ module.exports = {
     'react/prop-types': 1,
     // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}
     'react/destructuring-assignment': 0,
+    // Enforces type on buttons, e.g. <button type="submit" />
+    'react/button-has-type': 0,
+    // enforces order of lifecycle methods in a React class
+    'react/sort-comp': 0,
   },
 };

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -14,7 +14,7 @@ module.exports = {
     // eslint-ignore
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
     // Enforces adding prop-types. Added as a warning for backwards compatibility, but encouraged for future use & refactor
-    'react/prop-types': 1,
+    'react/prop-types': 0,
     // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}
     'react/destructuring-assignment': 0,
     // Enforces type on buttons, e.g. <button type="submit" />

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -19,7 +19,9 @@ module.exports = {
     'react/destructuring-assignment': 0,
     // Enforces type on buttons, e.g. <button type="submit" />
     'react/button-has-type': 0,
-    // enforces order of lifecycle methods in a React class
+    // Enforces order of lifecycle methods in a React class
     'react/sort-comp': 0,
+    // Allows you to add a list of prop types that will be forbidden
+    'react/forbid-prop-types': 0,
   },
 };

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -7,21 +7,22 @@ module.exports = {
     'react/react-in-jsx-scope': 0,
     // warns if a class-based component should be a functional component
     'react/prefer-stateless-function': 1,
-    // prevents characters that you may have meant as JSX escape characters from being accidentally injected as a text node in JSX statements.
+    // prevents characters that you may have meant as JSX escape characters from being accidentally injected as a text node in JSX statements. Backwards compatibility
     'react/no-unescaped-entities': 0,
-    // ensures that any non-required prop types of a component has a corresponding defaultProps value.
+    // ensures that any non-required prop types of a component has a corresponding defaultProps value. Disabled for backwards compatibility.
     'react/require-default-props': 0,
+    // Defines file extensions that are allowed to have jsx. Allowing .js because all of our non-ts jsx files have a .js extension.
     // eslint-ignore
-    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx', '.tsx'] }],
     // Enforces adding prop-types. Disabled for backwards compatibility, but encouraged for future use & refactor
     'react/prop-types': 0,
-    // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}
+    // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}. Disabling because it's too strict, and there are cases where each are better to be used.
     'react/destructuring-assignment': 0,
-    // Enforces type on buttons, e.g. <button type="submit" />
+    // Enforces type on buttons, e.g. <button type="submit" />. Disabling for backwards compabitibility.
     'react/button-has-type': 0,
-    // Enforces order of lifecycle methods in a React class
+    // Enforces order of lifecycle methods in a React class. Disabling for backwards compabitibility and low benefit to implement.
     'react/sort-comp': 0,
-    // Allows you to add a list of prop types that will be forbidden
+    // Allows you to add a list of prop types that will be forbidden. Disabling for backwards compabitibility.
     'react/forbid-prop-types': 0,
     // Enforces that every state variable is used. Disabling for backwards compatibility.
     'react/no-unused-state': 0,

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -1,4 +1,5 @@
 module.exports = {
+  plugins: ['react'],
   rules: {
     // warns if an array index is used as a key
     'react/no-array-index-key': 1,

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -13,5 +13,9 @@ module.exports = {
     'react/require-default-props': 0,
     // eslint-ignore
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
+    // Enforces adding prop-types. Added as a warning for backwards compatibility, but encouraged for future use & refactor
+    'react/prop-types': 1,
+    // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}
+    'react/destructuring-assignment': 0,
   },
 };

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -13,7 +13,7 @@ module.exports = {
     'react/require-default-props': 0,
     // eslint-ignore
     'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx'] }],
-    // Enforces adding prop-types. Added as a warning for backwards compatibility, but encouraged for future use & refactor
+    // Enforces adding prop-types. Disabled for backwards compatibility, but encouraged for future use & refactor
     'react/prop-types': 0,
     // Enforces destructuring props, and flags usages of directly instantiating, such as foo={props.bar}
     'react/destructuring-assignment': 0,
@@ -23,5 +23,14 @@ module.exports = {
     'react/sort-comp': 0,
     // Allows you to add a list of prop types that will be forbidden
     'react/forbid-prop-types': 0,
+    // Enforces that every state variable is used. Disabling for backwards compatibility.
+    'react/no-unused-state': 0,
+    // Makes sure every ref that is passed is a ref object, not a string. Disabled for backwards compatibility.
+    /*
+      <div className="foo" ref="Hello world">
+    */
+    'react/no-string-refs': 0,
+    // Bad: { ...props }. Disabling because this can be a helpful tool to reduce boilerplate.
+    'react/jsx-props-no-spreading': 0,
   },
 };


### PR DESCRIPTION
Adjusted rules to be less strict than the original version. Trying to balance cost of implementation vs. appearance in the Juni codebase. My goal is not necessarily to get to inbox 0 (based on conversation [here](https://github.com/JuniLearning/juni-app-frontend/pull/188)), but include the preferred ruleset, and allow for easy incremental refactoring on old areas of the codebase over time. The idea is that the rest of the rules that are still throwing errors would be fixed manually over the course of ~1 week.

Current [eslint-nibble](https://github.com/IanVS/eslint-nibble) count on FE codebase after running `lint:fix`:
*note that I left `react/prop-types` as a warning, because that would be a good area to refactor in the future, though pretty high cost. I wouldn't be at all opposed to removing altogether, though*

![Screen Shot 2020-09-18 at 3 58 52 PM](https://user-images.githubusercontent.com/36747395/93644581-e9877c00-f9c7-11ea-9e20-3767a358e7dd.png)

Opening this PR for a source of discussion other rules to disable.
