### PR TITLE
Disable formatOnSave for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Add the following to `./.vscode/settings.json`:
   "[javascriptreact]": {
     "editor.formatOnSave": false
   },
+  "[typescript]": {
+    "editor.formatOnSave": false
+  },
+  "[typescriptreact]": {
+    "editor.formatOnSave": false
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
I had issues with VSCode's formatter activating in addition to ESLint auto-fix. It seems that using Prettier suppresses this since you swap VSCode's formatter with Prettier, which has its own config. Adding these lines fixed it. 