### PR TITLE
Add state-in-constructor rule

### DIFF
--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -27,7 +27,7 @@ module.exports = {
     // Enforces that every state variable is used. Disabling for backwards compatibility.
     'react/no-unused-state': 0,
     // Enforces state initialization style
-    'react/state-in-constructor': ['error', 'never'],
+    'react/state-in-constructor': [2, 'never'],
     // Makes sure every ref that is passed is a ref object, not a string. Disabled for backwards compatibility.
     /*
       <div className="foo" ref="Hello world">

--- a/packages/react/rules/react.js
+++ b/packages/react/rules/react.js
@@ -26,6 +26,8 @@ module.exports = {
     'react/forbid-prop-types': 0,
     // Enforces that every state variable is used. Disabling for backwards compatibility.
     'react/no-unused-state': 0,
+    // Enforces state initialization style
+    'react/state-in-constructor': ['error', 'never'],
     // Makes sure every ref that is passed is a ref object, not a string. Disabled for backwards compatibility.
     /*
       <div className="foo" ref="Hello world">


### PR DESCRIPTION
Currently, we are using `eslint-config-airbnb@18.0.0`. Trying to upgrade creates a bunch of `react/state-in-constructor` linting warnings because the configuration changed between 18.0.0 and 18.0.1 (see [changelog](https://github.com/airbnb/javascript/blob/37d48dbf6082bd8958fdc5db5df207bb1166d653/packages/eslint-config-airbnb/CHANGELOG.md#1801--2019-08-13)). Therefore, I went ahead and added this rule to our config so that we can upgrade that package without incurring all of those warnings. Note that the way I have configured it is the way that it will eventually be configured in `eslint-config-airbnb`, according to this [TODO](https://github.com/airbnb/javascript/blob/ea5ec0c5242a4b987eb4a2861d65298450fb05d0/packages/eslint-config-airbnb/rules/react.js#L485).

With this rule added, linting will pass on the FE with the latest linting-related packages and no other changes.