### PR TITLE
Use 'warn' rather than 'error' for prettier rules

### DIFF
--- a/packages/base/rules/prettier.js
+++ b/packages/base/rules/prettier.js
@@ -2,7 +2,7 @@ module.exports = {
   plugins: ['prettier'],
   rules: {
     'prettier/prettier': [
-      'error',
+      'warn',
       {
         // If an arrow function has one parameter, don't use parenthesis: e.g. const foo = bar => value; vs. const foo = (bar) => value;
         arrowParens: 'avoid',


### PR DESCRIPTION
Downgrades violations of `prettier` rules from errors to warnings. We already ensure that the linting action on GH fails if there are warnings, so this will not affect the success/failure of that action.