### PR TITLE
Change name of publish script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,7 @@ npm i np -g
 ```bash
 np --no-tests
 ```
+
+```bash
+npm run release
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.43",
+  "version": "0.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.43",
+  "version": "0.0.46",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "./test.sh",
-    "publish": "npx np --no-tests --any-branch",
+    "release": "npx np --no-tests --any-branch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-juni",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "NPM package for shared ESLint config used at JuniLearning.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR changes the `publish` command to `release` as it causes local issues with `np` (the publishing tool that this repo uses).

Also bumps the version as I ran `npm run release` from this branch to publish 0.0.48.